### PR TITLE
Upgrade NDK version for CI build error

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -6,7 +6,6 @@ on:
       - dev
       - master
       - action_test
-      - fix-ci
 
 jobs:
   test:

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -6,6 +6,7 @@ on:
       - dev
       - master
       - action_test
+      - fix-ci
 
 jobs:
   test:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 28
-    ndkVersion "21.4.7075529"
+    ndkVersion "26.0.10792818"
 
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
Upgrade NDK version for build error in the following log in CI.

```
...
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:stripReleaseDebugSymbols'.
> No version of NDK matched the requested version 21.4.7075529. Versions available locally: 23.2.8568313, 24.0.8215888, 25.2.9519[65](https://github.com/flutter-webrtc/flutter-webrtc-demo/actions/runs/6173310379/job/16755352823#step:7:66)3, 25.2.9519653

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org/

BUILD FAILED in 3m 54s
Running Gradle task 'assembleRelease'...                          235.0s
Gradle task assembleRelease failed with exit code 1
Error: Process completed with exit code 1.
```